### PR TITLE
Improve large graph experience: add grid mode and optimize velocity calculation

### DIFF
--- a/src/components/GeneralSettings.tsx
+++ b/src/components/GeneralSettings.tsx
@@ -151,6 +151,16 @@ export function GeneralSettings({ directed, settings, setSettings }: Props) {
         )}
 
         <SettingsToggleSection
+          title={settings.language == "en" ? "Grid Mode" : "help idk chinese"}
+          leftLabel={settings.language == "en" ? "Off" : "关闭"}
+          rightLabel={settings.language == "en" ? "On" : "开启"}
+          toggleId={"gridMode"}
+          settingsName={"gridMode"}
+          settings={settings}
+          setSettings={setSettings}
+        />
+
+        <SettingsToggleSection
           title={settings.language == "en" ? "Lock Mode" : "锁定模式"}
           leftLabel={settings.language == "en" ? "Off" : "关闭"}
           rightLabel={settings.language == "en" ? "On" : "开启"}

--- a/src/components/SettingsToggleSection.tsx
+++ b/src/components/SettingsToggleSection.tsx
@@ -10,6 +10,31 @@ interface Props {
   setSettings: React.Dispatch<React.SetStateAction<Settings>>;
 }
 
+function fixSettingsModes(newSettings: Settings, settingsName: string) {
+  if (
+    newSettings.bipartiteMode &&
+    settingsName === "bipartiteMode"
+  ) {
+    newSettings["treeMode"] = false;
+    newSettings["gridMode"] = false;
+    newSettings["showComponents"] = false;
+  }
+  if (newSettings.treeMode && settingsName === "treeMode") {
+    newSettings["bipartiteMode"] = false;
+    newSettings["gridMode"] = false;
+  }
+  if (
+    newSettings.showComponents &&
+    settingsName === "showComponents"
+  ) {
+    newSettings["bipartiteMode"] = false;
+  }
+  if (newSettings.gridMode && settingsName === "gridMode") {
+    newSettings["treeMode"] = false;
+    newSettings["bipartiteMode"] = false;
+  }
+}
+
 export function SettingsToggleSection({
   title,
   leftLabel,
@@ -38,22 +63,7 @@ export function SettingsToggleSection({
                       ...settings,
                       [settingsName]: false,
                     };
-                    if (
-                      newSettings.bipartiteMode &&
-                      settingsName === "bipartiteMode"
-                    ) {
-                      newSettings["treeMode"] = false;
-                      newSettings["showComponents"] = false;
-                    }
-                    if (newSettings.treeMode && settingsName === "treeMode") {
-                      newSettings["bipartiteMode"] = false;
-                    }
-                    if (
-                      newSettings.showComponents &&
-                      settingsName === "showComponents"
-                    ) {
-                      newSettings["bipartiteMode"] = false;
-                    }
+                    fixSettingsModes(newSettings, settingsName);
                     if (settingsName === "darkMode") {
                       localStorage.setItem(
                         "darkMode",
@@ -93,22 +103,7 @@ export function SettingsToggleSection({
                       ...settings,
                       [settingsName]: true,
                     };
-                    if (
-                      newSettings.bipartiteMode &&
-                      settingsName === "bipartiteMode"
-                    ) {
-                      newSettings["treeMode"] = false;
-                      newSettings["showComponents"] = false;
-                    }
-                    if (newSettings.treeMode && settingsName === "treeMode") {
-                      newSettings["bipartiteMode"] = false;
-                    }
-                    if (
-                      newSettings.showComponents &&
-                      settingsName === "showComponents"
-                    ) {
-                      newSettings["bipartiteMode"] = false;
-                    }
+                    fixSettingsModes(newSettings, settingsName);
                     if (settingsName === "darkMode") {
                       localStorage.setItem(
                         "darkMode",
@@ -142,22 +137,7 @@ export function SettingsToggleSection({
                   ...settings,
                   [settingsName]: !settings[settingsName],
                 };
-                if (
-                  newSettings.bipartiteMode &&
-                  settingsName === "bipartiteMode"
-                ) {
-                  newSettings["treeMode"] = false;
-                  newSettings["showComponents"] = false;
-                }
-                if (newSettings.treeMode && settingsName === "treeMode") {
-                  newSettings["bipartiteMode"] = false;
-                }
-                if (
-                  newSettings.showComponents &&
-                  settingsName === "showComponents"
-                ) {
-                  newSettings["bipartiteMode"] = false;
-                }
+                fixSettingsModes(newSettings, settingsName);
                 if (settingsName === "darkMode") {
                   localStorage.setItem(
                     "darkMode",

--- a/src/components/graphGrid.ts
+++ b/src/components/graphGrid.ts
@@ -1,0 +1,191 @@
+import { Position, PositionMap } from "../types";
+
+interface Cell {
+  i: number,
+  j: number,
+}
+
+function genRandom(r: number): number {
+  return Math.floor(Math.random() * r);
+}
+
+function distance(a: Cell, b: Cell): number {
+  return Math.hypot(a.i - b.i, a.j - b.j);
+}
+
+const TIME_LIMIT_SECONDS = 0.25;
+
+export function buildGraphGrid(
+  nodes: string[],
+  adjMap: Map<string, Set<string>>,
+  aspectRatio: number,
+): PositionMap {
+  let gridWidth = 1;
+  let gridHeight = 1;
+  while (gridWidth * gridHeight < nodes.length) {
+    if (gridWidth / gridHeight < aspectRatio) {
+      gridWidth += 1;
+    } else {
+      gridHeight += 1;
+    }
+  }
+
+  const nodeIndex = new Map<String, number>();
+  for (let i = 0; i < nodes.length; ++i) {
+    nodeIndex.set(nodes[i], i);
+  }
+
+  const adj = new Array<Array<number>>();
+  for (let i = 0; i < nodes.length; ++i) {
+    const adjList = new Array<number>();
+    for (const node of adjMap.get(nodes[i])!) {
+      adjList.push(nodeIndex.get(node)!);
+    }
+    adj.push(adjList);
+  }
+
+  let nodeCell = new Array(gridWidth * gridHeight).fill({i: 0, j: 0});
+  // This makes it easier to allow swaps between reals nodes and empty cells later
+  while (adj.length < nodeCell.length) {
+    adj.push(new Array<number>());
+  }
+
+  // Run bfs for every component, place each vertex as close to its parent as possible
+  {
+    const used = new Array(adj.length).fill(false);
+    const usedCells = new Array<Array<boolean>>();
+    for (let i = 0; i < gridWidth; ++i) {
+      usedCells.push(new Array(gridHeight).fill(false));
+    }
+    for (let v = 0; v < adj.length; ++v) {
+      if (used[v]) {
+        continue;
+      }
+      const queue = new Array<number>();
+      queue.push(v);
+      used[v] = true;
+      {
+        let found = false;
+        for (let i = 0; i < gridWidth; ++i) {
+          for (let j = 0; j < gridHeight; ++j) {
+            if (!usedCells[i][j]) {
+              usedCells[i][j] = true;
+              nodeCell[v] = {i, j};
+              found = true;
+              break;
+            }
+          }
+          if (found) {
+            break;
+          }
+        }
+      }
+      let iqueue = 0;
+      while (iqueue < queue.length) {
+        let v = queue[iqueue];
+        ++iqueue;
+        const {i, j} = nodeCell[v];
+        let minDist = 1;
+        for (const u of adj[v]) {
+          if (used[u]) {
+            continue;
+          }
+          let found = false;
+          // Technically this iterates in the order of increasing Manhattan distance, and later we optimize Euclidean distance, but it's fiiine
+          for (; minDist <= gridWidth + gridHeight; ++minDist) {
+            for (let di = -minDist; di <= minDist; ++di) {
+              if (i + di < 0 || i + di >= gridWidth) {
+                continue;
+              }
+              const djabs = minDist - Math.abs(di);
+              for (const dj of [-djabs, djabs]) {
+                if (j + dj < 0 || j + dj >= gridHeight) {
+                  continue;
+                }
+                if (!usedCells[i + di][j + dj]) {
+                  usedCells[i + di][j + dj] = true;
+                  nodeCell[u] = {i: i + di, j: j + dj};
+                  found = true;
+                  break;
+                }
+              }
+              if (found) {
+                break;
+              }
+            }
+            if (found) {
+              break;
+            }
+          }
+          queue.push(u);
+          used[u] = true;
+        }
+      }
+    }
+  }
+
+  let totalDistance = 0;
+  for (let u = 0; u < nodes.length; ++u) {
+    for (const v of adj[u]) {
+      if (u < v) {
+        totalDistance += distance(nodeCell[u], nodeCell[v]);
+      }
+    }
+  }
+
+  // Randomly swap nodes if it decreases total edge length
+  if (nodes.length >= 2) {
+    const startTime = performance.now();
+    for (let it = 0; it < nodes.length * nodes.length * 10; ++it) {
+      if ((performance.now() - startTime) / 1000 > TIME_LIMIT_SECONDS) {
+        console.log("Iters:", it);
+        break;
+      }
+      const u = genRandom(adj.length);
+      let v = u;
+      while (u === v) {
+        v = genRandom(adj.length);
+      }
+
+      function swapCells() {
+        let tmp = nodeCell[u];
+        nodeCell[u] = nodeCell[v];
+        nodeCell[v] = tmp;
+      }
+
+      let diff = 0;
+      for (const node of [u, v]) {
+        for (const x of adj[node]) {
+          if (x !== u && x !== v) {
+            diff -= distance(nodeCell[node], nodeCell[x]);
+          }
+        }
+      }
+      swapCells();
+      for (const node of [u, v]) {
+        for (const x of adj[node]) {
+          if (x !== u && x !== v) {
+            diff += distance(nodeCell[node], nodeCell[x]);
+          }
+        }
+      }
+
+      if (diff <= 0) {
+        totalDistance += diff;
+      } else {
+        swapCells();
+      }
+    }
+  }
+
+  const result = new Map<string, Position>();
+  for (let i = 0; i < nodes.length; ++i) {
+    result.set(nodes[i], [nodeCell[i].i + 0.5, nodeCell[i].j + 0.5]);
+  }
+
+  return {
+    positions: result,
+    gridWidth,
+    gridHeight,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export interface Settings {
   showMSTs: boolean;
   treeMode: boolean;
   bipartiteMode: boolean;
+  gridMode: boolean,
   lockMode: boolean;
   markedNodes: boolean;
   fixedMode: boolean;
@@ -67,5 +68,12 @@ export type BackedgeMap = Map<string, boolean>;
 export type BridgeMap = Map<string, boolean>;
 
 export type MSTMap = Map<string, boolean>;
+
+export type Position = [number, number];
+export interface PositionMap {
+  positions: Map<string, Position>;
+  gridWidth: number;
+  gridHeight: number;
+}
 
 export type MarkBorder = "single" | "double";


### PR DESCRIPTION
Fixes https://github.com/anAcc22/another_graph_editor/issues/8

Firstly, just improve velocity calculation, now it works significantly faster for sparse graphs and most of the time (96%) is spent on the rendering itself. On my laptop animation of the 900-node tree from the issue achieves around 20-30 fps.

It does change the physics a bit, i.e. now every interaction only happens through edges. Maybe it will be worth to turn it on only for large graphs?

Though it's still impossible to extract any useful info from the visualization, so I added a mode to try to minimize edge intersections. It works like this &mdash; let's try to place vertices of the graph on a square grid: start at an arbitrary node, then visit other nodes in the BFS order and try to place each one as close to the parent as possible. In the end do some local optimizations to fix obvious inefficiencies.

There are probably better planarization algorithms, but this one is simple enough and it works, and tbh for this particular graph I doubt you can get a much better result.

It works with components as well:

![image](https://github.com/user-attachments/assets/dd91f32f-e0be-4a63-9fcc-ff3785110cde)
_I removed a couple of edges from the original graph for this picture_