### PR TITLE
Fix #45

### DIFF
--- a/src/components/animateGraph.ts
+++ b/src/components/animateGraph.ts
@@ -553,10 +553,10 @@ function buildSettings(): void {
       colorMap = buildComponents(nodes, adj, rev);
     }
     if (settings.showEBCC) {
-      [colorMap, ebccEdgeMap] = buildEBCC(nodes, edges);
+      [colorMap, ebccEdgeMap] = buildEBCC(nodes, edges, FILL_COLORS_LENGTH);
     }
     if (settings.showVBCC) {
-      [vbccColorMap, vbccEdgeMap] = buildVBCC(nodes, edges);
+      [vbccColorMap, vbccEdgeMap] = buildVBCC(nodes, edges, FILL_COLORS_LENGTH);
     }
     if (settings.treeMode) {
       [layerMap, backedgeMap] = buildTreeLayers(nodes, adj, rev);

--- a/src/components/graphEBCC.ts
+++ b/src/components/graphEBCC.ts
@@ -1,8 +1,67 @@
 import { ColorMap, EBCCEdgeMap } from "../types";
 
+function remapColor(
+  belong: Map<string, number>,
+  edges: string[],
+  colorNum: number,
+): Map<number, number> {
+  let colors = new Set<Number>();
+  for (let i = 0; i < colorNum; i++) {
+    colors.add(i);
+  }
+
+  let adj = new Map<number, Set<number>>();
+  for (const [_, belongTo] of belong) {
+    if (!adj.has(belongTo)) {
+      adj.set(belongTo, new Set());
+    }
+  }
+
+  for (const e of edges) {
+    let u = e.split(" ")[0];
+    let v = e.split(" ")[1];
+    let bu = belong.get(u)!;
+    let bv = belong.get(v)!;
+    if (bu !== bv) {
+      adj.get(bu)!.add(bv);
+      adj.get(bv)!.add(bu);
+    }
+  }
+
+  let colormap = new Map<number, number>();
+
+  let visited = new Set<number>();
+
+  const dfs = (node: number, parent: number | null): void => {
+    visited.add(node);
+    while (!colormap.has(node)) {
+      let c = colors.values().next().value as number;
+      colors.delete(c); colors.add(c + colorNum);
+      if (parent !== null && c % colorNum === colormap.get(parent!)! % colorNum) {
+        continue;
+      }
+      colormap.set(node, c);
+    }
+    for (const v of adj.get(node)!) {
+      if (v !== parent) {
+        dfs(v, node);
+      }
+    }
+  };
+
+  for (const [_, belongTo] of belong) {
+    if (!visited.has(belongTo)) {
+      dfs(belongTo, null);
+    }
+  }
+
+  return colormap;
+}
+
 export function buildEBCC(
   nodes: string[],
   edges: string[],
+  colorNum: number,
 ): [ColorMap, EBCCEdgeMap] {
 
   const adjFull = new Map<string, string[]>();
@@ -18,15 +77,15 @@ export function buildEBCC(
     adjFull.get(v)!.push(u);
   }
 
-  let colorMap: ColorMap = new Map<string, number>();
   
   let color = 0;
   let time = 0;
-
+  
   let dfn = new Map<string, number>();
   let low = new Map<string, number>();
   let stack: string[] = [];
-
+  
+  let belong: ColorMap = new Map<string, number>();
   let bcc = new Map<number, string[]>();
 
   const dfs = (u: string, parent: string | null): void => {
@@ -54,7 +113,7 @@ export function buildEBCC(
       do {
         w = stack.pop()!;
         component.push(w);
-        colorMap.set(w, color);
+        belong.set(w, color);
       } while (w !== u);
       bcc.set(color, component);
     }
@@ -66,7 +125,13 @@ export function buildEBCC(
     }
   }
 
+  let colorMap: ColorMap = new Map<string, number>();
   let edgeMap: EBCCEdgeMap = new Map<string, number[]>();
+  let remap = remapColor(belong, edges, colorNum);
+
+  for (const [node, belongTo] of belong) {
+    colorMap.set(node, remap.get(belongTo)!);
+  }
 
   for (const e of edges) {
     let u = e.split(" ")[0];
@@ -76,5 +141,3 @@ export function buildEBCC(
 
   return [colorMap, edgeMap];
 }
-
-

--- a/src/components/graphVBCC.ts
+++ b/src/components/graphVBCC.ts
@@ -1,8 +1,90 @@
 import { VBCCEdgeMap, VBCCColorMap } from "../types";
 
+function remapColor(
+  components: Map<number, string[]>,
+  colorNum: number,
+): Map<number, number> {
+  let colors = new Set<Number>();
+  for (let i = 0; i < colorNum; i++) {
+    colors.add(i);
+  }
+
+  let nodeAdj = new Map<string, number[]>();
+  let groupAdj = new Map<number, string[]>();
+
+  let colormap = new Map<number, number>();
+
+  for (const [idx, nodes] of components) {
+    if (nodes.length <= 1) {
+      let c = colors.values().next().value as number;
+      colors.delete(c); colors.add(c + colorNum);
+      colormap.set(idx, c);
+      continue;
+    }
+    for (const u of nodes) {
+      if (!nodeAdj.has(u)) {
+        nodeAdj.set(u, []);
+      }
+      nodeAdj.get(u)!.push(idx);
+    }
+    groupAdj.set(idx, nodes);
+  }
+
+  let visited = new Set<string>();
+
+  const dfs = (node: string | null, group: number | null, parent: number | string | null): void => {
+    if (node !== null) {
+      visited.add(node);
+      let unusedNum: number = parent === null ? colorNum : colorNum - 1;
+      let needNum: number = parent === null ? nodeAdj.get(node)!.length : nodeAdj.get(node)!.length - 1;
+      let colorList: number[] = [];
+      while (colorList.length < needNum) {
+        let c = colors.values().next().value as number;
+        colors.delete(c); colors.add(c + colorNum);
+        if (unusedNum <= colorNum && parent !== null && c % colorNum === colormap.get(parent as number)! % colorNum) {
+          continue;
+        }
+        colorList.push(c);
+      }
+      for (const v of nodeAdj.get(node)!) {
+        if (v !== parent) {
+          colormap.set(v, colorList.pop()!);
+          dfs(null, v, node);
+        }
+      }
+    }
+    if (group !== null) {
+      for (const v of groupAdj.get(group)!) {
+        if (v !== parent) {
+          dfs(v, null, group);
+        }
+      }
+    }
+  };
+
+  for (const [node, group] of nodeAdj) {
+    if (!visited.has(node)) {
+      dfs(node, null, null);
+    }
+    let set = new Set<number>();
+    for (const g of group) {
+      set.add(colormap.get(g)! % colorNum);
+    }
+    if (set.size < group.length) {
+      console.warn("BCC Coloring failed.\n"
+        + "Node " + node + " is in Too many components.\n"
+        + "Available colors: " + colorNum + ", adjacent components: " + group.length
+      );
+    }
+  }
+
+  return colormap;
+}
+
 export function buildVBCC(
   nodes: string[],
   edges: string[],
+  colorNum: number,
 ): [VBCCColorMap, VBCCEdgeMap] {
 
   const adjFull = new Map<string, string[]>();
@@ -82,6 +164,8 @@ export function buildVBCC(
   let colorMap = new Map<string, {edge: string | null, group: number}[]>();
   let edgeMap = new Map<string, number>();
 
+  let remap = remapColor(bcc, colorNum);
+
   for (const u of nodes) {
     colorMap.set(u, []);
   }
@@ -99,6 +183,7 @@ export function buildVBCC(
     if (nodeparent.get(u)! == nodeparent.get(v)!) {
       belong = nodeparent.get(u)!;
     }
+    belong = remap.get(belong)!;
     edgeMap.set(e, belong);
     colorMap.get(u)!.push({edge: e, group: belong});
     colorMap.get(v)!.push({edge: e, group: belong});
@@ -106,7 +191,7 @@ export function buildVBCC(
 
   for (const [idx, nodes] of bcc) {
     if (nodes.length <= 1) {
-      colorMap.set(nodes[0], [{edge: null, group: idx}]);
+      colorMap.set(nodes[0], [{edge: null, group: remap.get(idx)!}]);
     }
   }
 


### PR DESCRIPTION
I have implemented a greedy algorithm to recolor these components, ensuring that no adjacent BCCs are assigned the same color unless a node belongs to too many components (>= FILL_COLORS_LENGTH).

<img width="1203" height="428" alt="image" src="https://github.com/user-attachments/assets/568d9314-7235-43a3-8604-0f157ffc33b1" />

I think this approach provides a more comprehensive solution to the issue, as star-like graphs are relatively uncommon in practice.

<img width="700" height="506" alt="image" src="https://github.com/user-attachments/assets/5cb7219b-6963-4aa9-aaea-8f69bfe74962" />

(One of those rare cases where the graph exhibits a star-like structure)
